### PR TITLE
Fixes for OSX.

### DIFF
--- a/projects/premake4.lua
+++ b/projects/premake4.lua
@@ -5,22 +5,22 @@ solution "Bootil"
 	flags { "Symbols", "NoEditAndContinue", "NoPCH", "StaticRuntime", "EnableSSE" }
 	targetdir ( "../lib/" .. os.get() .. "/" .. _ACTION )
 	includedirs { "../include/", "../src/3rdParty/" }
-	
+
 	if os.is( "linux" ) or os.is( "macosx" ) then
 		buildoptions { "-fPIC" }
-		linkoptions  { "-fPIC" }
+		-- linkoptions  { "-fPIC" }  -- OSX does not need this for linking
 	end
-	
+
 	configurations
-	{ 
+	{
 		"Release",
 		"Debug"
 	}
-	
+
 configuration "Release"
 	defines { "NDEBUG" }
 	flags{ "OptimizeSpeed", "FloatFast" }
-	
+
 configuration "Debug"
 	defines { "_DEBUG" }
 	targetsuffix "_debug"
@@ -38,5 +38,3 @@ project "Bootil-Static"
 	files { "../src/**.*", "../include/**.*" }
 	kind "StaticLib"
 	targetname( "bootil_static" )
-
-    

--- a/src/Bootil/Threads/Mutex.cpp
+++ b/src/Bootil/Threads/Mutex.cpp
@@ -1,4 +1,4 @@
-#pragma once
+
 #include "Bootil/Bootil.h"
 #include "tinythreadpp/fast_mutex.h"
 

--- a/src/Bootil/Threads/Thread.cpp
+++ b/src/Bootil/Threads/Thread.cpp
@@ -1,4 +1,4 @@
-#pragma once
+
 #include "Bootil/Bootil.h"
 #include "tinythreadpp/tinythread.h"
 #include "tinythreadpp/fast_mutex.h"

--- a/src/Bootil/Threads/Utility.cpp
+++ b/src/Bootil/Threads/Utility.cpp
@@ -1,4 +1,4 @@
-#pragma once
+
 #include "Bootil/Bootil.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
Various fixes to get Bootil compiling in Xcode 4 on OSX.
