### PR TITLE
Fixed win32 warnings and errors

### DIFF
--- a/src/3rdParty/xzip/unzip.cc
+++ b/src/3rdParty/xzip/unzip.cc
@@ -42,6 +42,7 @@ typedef unsigned short WORD;
 #include <stdlib.h>
 #include <string.h>
 #include <tchar.h>
+#include <winnls.h>
 #include "unzip.h"
 #endif
 //

--- a/src/Bootil/Types/Buffer.cpp
+++ b/src/Bootil/Types/Buffer.cpp
@@ -152,7 +152,7 @@ namespace Bootil
 	{
 		int iWritten = 0;
 
-		for ( int i=0; i<str.length(); i++ )
+		for ( unsigned int i=0; i<str.length(); i++ )
 		{
 			WriteType<char>( str[i] );
 			iWritten++;

--- a/src/Bootil/Types/Math.cpp
+++ b/src/Bootil/Types/Math.cpp
@@ -8,7 +8,7 @@ class InitialRandomSeeder
 
 		InitialRandomSeeder()
 		{
-			Bootil::Math::Random::Seed( time(NULL) );
+			Bootil::Math::Random::Seed( static_cast< unsigned int >(time(NULL)) );
 		}
 };
 

--- a/src/Bootil/Types/String_Encode.cpp
+++ b/src/Bootil/Types/String_Encode.cpp
@@ -37,7 +37,7 @@ namespace Bootil
 			{
 				BString strOut;
 
-				for ( int i=0; i<strIn.length(); i++ )
+				for ( unsigned int i=0; i < strIn.length(); i++ )
 				{
 					if ( (48 <= strIn[i] && strIn[i] <= 57) || (65 <= strIn[i] && strIn[i] <= 90) || (97 <= strIn[i] && strIn[i] <= 122) || (strIn[i] == '~' || strIn[i] == '-' || strIn[i] == '_' || strIn[i] == '.' ) )
 					{

--- a/src/Bootil/Types/String_To.cpp
+++ b/src/Bootil/Types/String_To.cpp
@@ -1,5 +1,9 @@
 #include "Bootil/Bootil.h"
 
+#if WIN32
+	#define sscanf sscanf_s
+#endif
+
 namespace Bootil
 {
 	namespace String 

--- a/src/Bootil/Utility/Compression.cpp
+++ b/src/Bootil/Utility/Compression.cpp
@@ -32,9 +32,9 @@ namespace Bootil
 
 			bool Compress( const void* pData, unsigned int iLength, Bootil::Buffer& output )
 			{
-				int iStartPos = output.GetPos();
+				unsigned int iStartPos = output.GetPos();
 
-				if ( !output.EnsureCapacity( iStartPos + iLength * 1.5 ) )
+				if ( !output.EnsureCapacity( static_cast<unsigned int>(iStartPos + iLength * 1.5) ) )
 					return false;
 
 				int iSize = fastlz_compress_level( 2, pData, iLength, output.GetCurrent() );
@@ -64,7 +64,7 @@ namespace Bootil
 					//
 					if ( ret == -1 )
 					{
-						if ( !output.EnsureCapacity( output.GetSize() * 1.20f ) )
+						if ( !output.EnsureCapacity( static_cast<unsigned int>(output.GetSize() * 1.20f) ) )
 							return false;
 
 						continue;


### PR DESCRIPTION
- winnls.h required in unzip.cc.
- Fixed signed/unsigned warnings.
- Use sscanf_s on Windows.
