### PR TITLE
Hopefully fixed the performance issues with the symbolic link fix

### DIFF
--- a/include/Bootil/File/Changes.h
+++ b/include/Bootil/File/Changes.h
@@ -50,9 +50,10 @@ namespace Bootil
 				void CheckForChanges();
 				void StartWatch();
 
-				void*				m_pData;
-				char				m_Buffer[1024];
-				void* 				m_dirHandle;
+#ifdef __linux__
+				int                 m_inotify;
+#endif
+				void* 				m_dirHandles;
 				BString				m_strFolderName;
 				std::list<BString>	m_Changes;
 				bool				m_bWatchSubtree;

--- a/src/Bootil/File/Changes.cpp
+++ b/src/Bootil/File/Changes.cpp
@@ -1,32 +1,58 @@
-
 #include "Bootil/Bootil.h"
-
 #ifdef _WIN32
-#define _WIN32_WINNT  0x0502
+#define _WIN32_WINNT 0x0502
+
 #include <windows.h>
 #elif __linux__
 #include <unistd.h>
 #include <sys/select.h>
 #include <sys/inotify.h>
-
-typedef std::map<int, Bootil::BString> WatchMap;
+#endif
 
 namespace
 {
-	// Slightly ugly, but it works.
-	void RecurseDirectories( Bootil::String::List & folders, const Bootil::BString & folder )
+#ifdef _WIN32
+	const char separator = '\\';
+#elif __linux__
+	const char separator = '/';
+#endif
+	
+	struct WatcherData
 	{
-		Bootil::String::List curDir;
-		int i = Bootil::File::Find( NULL, &curDir, folder + "/*", false );
-		BOOTIL_FOREACH_CONST( f, curDir, Bootil::String::List )
+		Bootil::BString directory;
+#ifdef _WIN32
+		HANDLE directoryHandle;
+
+		OVERLAPPED overlapped;
+
+		char buffer[1024];
+#elif __linux__
+		int handle;
+#endif
+	};
+
+#ifdef __linux__
+	struct WatcherFind
+	{
+		int handle;
+
+		bool operator()(const WatcherData& b) { return handle == b.handle; }
+	};
+#endif
+
+	void RecurseDirectories( Bootil::String::List & directories, const Bootil::BString & path )
+	{
+		Bootil::String::List currentDirectory;
+
+		Bootil::File::Find( NULL, &currentDirectory, path + separator + "*", false );
+		BOOTIL_FOREACH_CONST( directory, currentDirectory, Bootil::String::List )
 		{
-			folders.push_back( *f );
-			RecurseDirectories( folders, *f );
+			Bootil::BString directoryPath = path + separator + *directory;
+			directories.push_back( directoryPath );
+			RecurseDirectories( directories, directoryPath );
 		}
 	}
 }
-
-#endif
 
 namespace Bootil
 {
@@ -34,72 +60,89 @@ namespace Bootil
 	{
 		ChangeMonitor::ChangeMonitor()
 		{
-			m_dirHandle		= NULL;
-			m_pData			= NULL;
-			m_bWatchSubtree	= false;
-			memset( m_Buffer, 0, sizeof( m_Buffer ) );
-#ifdef _WIN32
-			m_pData = ( void* )new OVERLAPPED;
-			memset( m_pData, 0, sizeof( OVERLAPPED ) );
-#elif __linux__
-			m_pData = ( void* )new int( inotify_init() );
+			m_dirHandles = NULL;
+#ifdef __linux__
+			m_inotify = inotify_init();
 #endif
 		}
 
 		ChangeMonitor::~ChangeMonitor()
 		{
-#ifdef _WIN32
-			delete( ( OVERLAPPED* )m_pData );
-#endif
 			Stop();
 #ifdef __linux__
-			close( *( int* )m_pData );
-			delete( int* )m_pData;
+			close(m_inotify);
 #endif
 		}
 
 		bool ChangeMonitor::WatchFolder( const BString & strFolder, bool bWatchSubtree )
 		{
 			Stop();
+
+			m_strFolderName = strFolder;
 			m_bWatchSubtree = bWatchSubtree;
+
+			m_dirHandles = new std::vector<WatcherData>;
+
+			// Watch the main folder.
+
+			WatcherData watcherData;
+
+			watcherData.directory = strFolder;
 #ifdef _WIN32
-			memset( m_pData, 0, sizeof( OVERLAPPED ) );
-			m_dirHandle = CreateFileA( strFolder.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL );
+			watcherData.directoryHandle = CreateFileA( watcherData.directory.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL );
 
-			if ( m_dirHandle == INVALID_HANDLE_VALUE )
-			{ return false; }
+			memset( &watcherData.overlapped, 0, sizeof( watcherData.overlapped ) );
+			watcherData.overlapped.hEvent = CreateEvent( NULL, FALSE, FALSE, NULL );
 
-			( ( OVERLAPPED* )m_pData )->hEvent = CreateEvent( NULL, FALSE, FALSE, NULL );
-			StartWatch();
+			std::fill( watcherData.buffer, watcherData.buffer + 1024, 0 );
 #elif __linux__
-			int flags = IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO;
-			int handle;
-			m_dirHandle = new WatchMap();
-			handle = inotify_add_watch( *( int* )m_pData, strFolder.c_str(), flags );
+			int flags = IN_ATTRIB | IN_CREATE | IN_DELETE | IN_MODIFY | IN_MOVED_FROM | IN_MOVED_TO;
+			watcherData.handle = inotify_add_watch( m_inotify, watcherData.directory.c_str(), flags );
 
-			if ( handle < 0 )
+			if ( watcherData.handle < 0 )
 			{ return false; }
+#endif
 
-			( *( WatchMap* )m_dirHandle )[handle] = strFolder;
+			( ( std::vector<WatcherData>* ) m_dirHandles )->push_back( watcherData );
 
-			if ( bWatchSubtree )
+			// And subfolders if we were told to.
+
+			if ( m_bWatchSubtree )
 			{
-				String::List folders;
-				RecurseDirectories( folders, strFolder );
-				BOOTIL_FOREACH_CONST( folder, folders, String::List )
+				Bootil::String::List directories;
+				RecurseDirectories( directories, strFolder );
+				BOOTIL_FOREACH_CONST( directory, directories, Bootil::String::List )
 				{
-					handle = inotify_add_watch( *( int* )m_pData, folder->c_str(), flags );
+					WatcherData watcherData;
 
-					if ( handle < 0 )
+					watcherData.directory = *directory;
+#ifdef _WIN32
+					watcherData.directoryHandle = CreateFileA( watcherData.directory.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, NULL );
+
+					// Windows automatically watches all the subfolders except for symbolic links. We need to watch them manually. So watch this one only if it's a symbolic link.
+
+					if ( !( GetFileAttributes( watcherData.directory.c_str() ) & FILE_ATTRIBUTE_REPARSE_POINT ) )
+					{
+						continue;
+					}
+
+					memset( &watcherData.overlapped, 0, sizeof( watcherData.overlapped ) );
+					watcherData.overlapped.hEvent = CreateEvent( NULL, FALSE, FALSE, NULL );
+
+					std::fill( watcherData.buffer, watcherData.buffer + 1024, 0 );
+#elif __linux__
+					watcherData.handle = inotify_add_watch( m_inotify, watcherData.directory.c_str(), flags );
+
+					if ( watcherData.handle < 0 )
 					{ return false; }
+#endif
 
-					( *( WatchMap* )m_dirHandle )[handle] = *folder;
+					( ( std::vector<WatcherData>* ) m_dirHandles )->push_back( watcherData );
 				}
 			}
 
 			StartWatch();
-#endif
-			m_strFolderName = strFolder;
+
 			return true;
 		}
 
@@ -114,30 +157,19 @@ namespace Bootil
 
 		void ChangeMonitor::Stop()
 		{
-			if ( m_dirHandle )
+			if ( !m_dirHandles ) { return; }
+
+			BOOTIL_FOREACH ( watcherData, ( *( std::vector<WatcherData>* ) m_dirHandles ), std::vector<WatcherData> )
 			{
 #ifdef _WIN32
-				CloseHandle( m_dirHandle );
-				m_dirHandle = NULL;
+				CloseHandle( watcherData->directoryHandle );
+				watcherData->directoryHandle = NULL;
 #elif __linux__
-				BOOTIL_FOREACH_CONST( handle, ( *( WatchMap* )m_dirHandle ), WatchMap )
-				{
-					inotify_rm_watch( *( int* )m_pData, handle->first );
-				}
-				delete( WatchMap* )m_dirHandle;
-				m_dirHandle = NULL;
+				inotify_rm_watch( m_inotify, watcherData->handle );
 #endif
 			}
 
-#ifdef _WIN32
-
-			if ( ( ( OVERLAPPED* )m_pData )->hEvent )
-			{
-				CloseHandle( ( ( OVERLAPPED* )m_pData )->hEvent );
-				( ( OVERLAPPED* )m_pData )->hEvent = NULL;
-			}
-
-#endif
+			delete ( std::vector<WatcherData>* ) m_dirHandles;
 		}
 
 		bool ChangeMonitor::HasChanges()
@@ -157,75 +189,110 @@ namespace Bootil
 
 		void ChangeMonitor::CheckForChanges()
 		{
-			if ( m_dirHandle == NULL ) { return; }
+			if ( !m_dirHandles ) { return; }
 
 #ifdef _WIN32
-			DWORD dwNumberbytes;
-
-			if ( !GetOverlappedResult( m_dirHandle, ( ( OVERLAPPED* )m_pData ), &dwNumberbytes, false ) )
-			{ return; }
-
-			ResetEvent( ( ( OVERLAPPED* )m_pData )->hEvent );
-			int iOffset = 0;
-
-			while ( true )
+			BOOTIL_FOREACH ( watcherData, ( *( std::vector<WatcherData>* ) m_dirHandles ), std::vector<WatcherData> )
 			{
-				FILE_NOTIFY_INFORMATION* pNotify = ( FILE_NOTIFY_INFORMATION* )&m_Buffer[iOffset];
-				BString strName = Bootil::String::Convert::FromWide( WString( pNotify->FileName, pNotify->FileNameLength / sizeof( wchar_t ) ) );
+				DWORD dwNumberBytes = 0;
 
-				if ( pNotify->FileNameLength > 0 )
+				GetOverlappedResult( watcherData->directoryHandle, &watcherData->overlapped, &dwNumberBytes, FALSE );
+
+				ResetEvent( watcherData->overlapped.hEvent );
+
+				if ( dwNumberBytes > 0 )
 				{
-					NoteFileChanged( strName );
-				}
+					int iOffset = 0;
+					while ( true )
+					{
+						FILE_NOTIFY_INFORMATION* pNotify = ( FILE_NOTIFY_INFORMATION* ) &watcherData->buffer[iOffset];
+						iOffset += pNotify->NextEntryOffset;
+						
+						if ( pNotify->FileNameLength > 0 )
+						{
+							// Found a changed file. Get the relative path to it.
 
-				if ( pNotify->NextEntryOffset == 0 )
-				{
-					StartWatch();
-					return;
-				}
+							BString path;
 
-				iOffset += pNotify->NextEntryOffset;
+							if ( watcherData->directory == m_strFolderName )
+							{
+								path = "";
+							}
+							else
+							{
+								path = watcherData->directory.substr( m_strFolderName.size() + 1 ) + separator;	
+							}
+
+							path += Bootil::String::Convert::FromWide( WString( pNotify->FileName, pNotify->FileNameLength / sizeof( wchar_t ) ) );
+
+							// Add it to the change list.
+
+							NoteFileChanged( path );
+						}
+
+						if ( pNotify->NextEntryOffset == 0 )
+						{
+							break;
+						}
+					}
+
+					// We reached the end of the changes. Start looking for them again.
+
+					CancelIo( watcherData->directoryHandle );
+
+					std::fill( watcherData->buffer, watcherData->buffer + 1024, 0 );
+
+					ReadDirectoryChangesW( watcherData->directoryHandle, &watcherData->buffer, sizeof( watcherData->buffer ), m_bWatchSubtree, FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_LAST_WRITE, NULL, &watcherData->overlapped, NULL );
+				}
 			}
-
 #elif __linux__
-			int inotify_fd = *( int* )m_pData;
-			timeval timeout;
-			timeout.tv_sec = 0;
-			timeout.tv_usec = 0;
+			timeval tv;
+			tv.tv_sec = tv.tv_usec = 0;
+
 			fd_set fds;
 			FD_ZERO( &fds );
-			FD_SET( inotify_fd, &fds );
-			select( inotify_fd + 1, &fds, NULL, NULL, &timeout );
+			FD_SET( m_inotify, &fds );
+			
+			select( m_inotify + 1, &fds, NULL, NULL, &tv );
 
-			if ( FD_ISSET( inotify_fd, &fds ) )
+			if ( FD_ISSET( m_inotify, &fds ) )
 			{
-				int i = 0;
-				int ret = read( inotify_fd, m_Buffer, sizeof( m_Buffer ) );
+				char buffer[1024];
+
+				int i = 0, ret = read( m_inotify, buffer, 1024 );
 
 				if ( ret < 0 )
 				{ return; }
 
 				while ( i < ret )
 				{
-					inotify_event* event = ( inotify_event* )&m_Buffer[i];
+					inotify_event* event = ( inotify_event* )&buffer[i];
+					std::vector<WatcherData>& watches = *( std::vector<WatcherData>* ) m_dirHandles;
+					WatcherFind find = { .handle = event->wd };
+					std::vector<WatcherData>::const_iterator it = std::find_if(watches.begin(), watches.end(), find);
 
-					if ( event->len > 0 )
+					if ( event->len > 0 && it != watches.end() )
 					{
-						NoteFileChanged( ( *( WatchMap* )m_dirHandle )[event->wd] + "/" + event->name );
+						NoteFileChanged( it->directory + separator + event->name );
 					}
 
 					i += sizeof( inotify_event ) + event->len;
 				}
 			}
-
 #endif
 		}
 
 		void ChangeMonitor::StartWatch()
 		{
 #ifdef _WIN32
-			ReadDirectoryChangesW( m_dirHandle, m_Buffer, sizeof( m_Buffer ), m_bWatchSubtree, FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_LAST_WRITE, NULL, ( ( OVERLAPPED* )m_pData ), NULL );
+			BOOTIL_FOREACH ( watcherData, ( *( std::vector<WatcherData>* ) m_dirHandles ), std::vector<WatcherData> )
+			{
+				std::fill( watcherData->buffer, watcherData->buffer + 1024, 0 );
+
+				ReadDirectoryChangesW( watcherData->directoryHandle, &watcherData->buffer, sizeof( watcherData->buffer ), m_bWatchSubtree, FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_LAST_WRITE, NULL, &watcherData->overlapped, NULL );
+			}
 #endif
+
 			CheckForChanges();
 		}
 	}


### PR DESCRIPTION
I managed to get the average time spent in HasChanges down from 12.7 milliseconds to a whooping 0.17 milliseconds (in a debug build, release is probably even faster).

So the core problem with symbolic links was that ReadDirectoryChangesW ignores changes happening inside symbolic links even if bWatchSubtree is true. It works if the main directory itself is a symbolic link though.

I previously fixed this by calling ReadDirectoryChangesW for each subdirectory. I didn't realize that it would have such a large performance penalty.

The new logic is to call ReadDirectoryChangesW only for each subdirectory that is a symbolic link.