### PR TITLE
Added OS X Platform::FindFiles support; fixed Linux implementation

### DIFF
--- a/src/Bootil/Platform/Platform_LINUX.cpp
+++ b/src/Bootil/Platform/Platform_LINUX.cpp
@@ -178,13 +178,13 @@ namespace Bootil
 					{
 						if ( bUpUpFolders || ( name != "." && name != ".." ) )
 						{
-							folders->push_back( fullName );
+							folders->push_back( name );
 							iFiles++;
 						}
 					}
 					else if ( files )
 					{
-						files->push_back( fullName );
+						files->push_back( name );
 						iFiles++;
 					}
 				}
@@ -257,7 +257,7 @@ namespace Bootil
 
 		BOOTIL_EXPORT long long GetMilliseconds()
 		{
-			static int      startSeconds = 0;
+			static time_t   startSeconds = 0;
 
 			struct timeval  timecurrent;
 			gettimeofday( &timecurrent, NULL );


### PR DESCRIPTION
* OS X was missing a Platform::FindFiles implementation. It is added now.
* The Linux implementation was inconsistent to Windows as it returned absolute paths unlike Windows. This has been fixed now.
* Also added OS X support for Platform::LastError and Platform::CurrentUserName as a bonus.

Probably fixed GMad issues as a result.