### PR TITLE
Added forgotten standard includes.

### DIFF
--- a/include/Bootil/Types/String.h
+++ b/include/Bootil/Types/String.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 //
 // Original function alters passed string - we define a Get# version of that
 // function which returns the result instead - leaving the original string untouched.

--- a/include/Bootil/Utility/Compression.h
+++ b/include/Bootil/Utility/Compression.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace Bootil
 {
 	namespace Compression


### PR DESCRIPTION
Silly mistake, but you replaced types `uint64_t` without adding the include header `stdint.h`. :)
This broke compilation on GCC, this pull request simply fixes that.